### PR TITLE
`poetry: command not found` fix

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -6,7 +6,7 @@ curl -sSL https://install.python-poetry.org/ --output "$installation_script"
 if [ "${RUNNER_OS}" == "Windows" ]; then
     path="C:/Users/runneradmin/AppData/Roaming/Python/Scripts"
 else
-    path="$HOME/.local/"
+    path="$HOME/.local"
 fi
 
 echo -e "\n\033[33mSetting Poetry installation path as $path\033[0m\n"
@@ -24,7 +24,7 @@ export PATH="$path/bin:$PATH"
 if [ "${RUNNER_OS}" == "Windows" ]; then
     poetry_="$path/bin/poetry.exe"
 else
-    poetry_=poetry
+    poetry_="$path/bin/poetry"
 fi
 
 # Expand any "~" in VIRTUALENVS_PATH


### PR DESCRIPTION
Attempting a fix for `poetry: command not found`. 

My logs were:
```
$GITHUB_ACTION_PATH/main.sh
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.6.15/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.6.15/x64/lib
    VERSION: 1.2.0
    VIRTUALENVS_CREATE: true
    VIRTUALENVS_IN_PROJECT: true
    VIRTUALENVS_PATH: {cache-dir}/virtualenvs
    INSTALLER_PARALLEL: true
    INSTALLATION_ARGUMENTS: 

Setting Poetry installation path as /home/runner/.local/

Installing Poetry 👷

Retrieving Poetry metadata

# Welcome to Poetry!

This will download and install the latest version of Poetry,
a dependency and package manager for Python.

It will add the `poetry` command to Poetry's bin directory, located at:

/home/runner/.local/bin

You can uninstall at any time by executing this script with the --uninstall option,
and these changes will be reverted.

Installing Poetry (1.2.0)
Installing Poetry (1.2.0): Creating environment
Installing Poetry (1.2.0): Installing Poetry
Installing Poetry (1.2.0): Creating script
Installing Poetry (1.2.0): Done

Poetry (1.2.0) is installed now. Great!

You can test that everything is set up by executing:

`poetry --version`

/home/runner/work/_actions/snok/install-poetry/v1.3.1/main.sh: line 33: poetry: command not found
/home/runner/work/_actions/snok/install-poetry/v1.3.1/main.sh: line 34: poetry: command not found
/home/runner/work/_actions/snok/install-poetry/v1.3.1/main.sh: line 35: poetry: command not found
/home/runner/work/_actions/snok/install-poetry/v1.3.1/main.sh: line 37: poetry: command not found

Installation completed. Configuring settings 🛠

Done ✅

If you are creating a venv in your project, you can activate it by running 'source .venv/bin/activate'. If you're running this in an OS matrix, you can use 'source $VENV' instead, as an OS agnostic option
```